### PR TITLE
Add support for single-quoted hash keys.

### DIFF
--- a/plugin/rubyhash.vim
+++ b/plugin/rubyhash.vim
@@ -7,6 +7,12 @@ if g:rubyhash_map_keys==1
   nnoremap <silent> <Leader>rt :call ToStringKeysLinewise()<CR>
   nnoremap <silent> <Leader>rr :call To19KeysLinewise()<CR>
   nnoremap <silent> <Leader>rq :call ToSingleQuotedStringKeysLinewise()<CR>
+ 
+  " add bindings that work in visual line mode
+  vnoremap <silent> <Leader>rs :call ToSymbolKeysLinewise()<CR>
+  vnoremap <silent> <Leader>rt :call ToStringKeysLinewise()<CR>
+  vnoremap <silent> <Leader>rr :call To19KeysLinewise()<CR>
+  vnoremap <silent> <Leader>rq :call ToSingleQuotedStringKeysLinewise()<CR>
 endif
 
 function! ToSymbolKeysLinewise()

--- a/plugin/rubyhash.vim
+++ b/plugin/rubyhash.vim
@@ -6,6 +6,7 @@ if g:rubyhash_map_keys==1
   nnoremap <silent> <Leader>rs :call ToSymbolKeysLinewise()<CR>
   nnoremap <silent> <Leader>rt :call ToStringKeysLinewise()<CR>
   nnoremap <silent> <Leader>rr :call To19KeysLinewise()<CR>
+  nnoremap <silent> <Leader>rq :call ToSingleQuotedStringKeysLinewise()<CR>
 endif
 
 function! ToSymbolKeysLinewise()
@@ -18,6 +19,10 @@ endfunction
 
 function! ToStringKeysLinewise()
   :ruby Convert::to_strings
+endfunction
+
+function! ToSingleQuotedStringKeysLinewise()
+  :ruby Convert::to_single_quoted_strings
 endfunction
 
 ruby << EOF
@@ -33,6 +38,13 @@ module Convert
     search_and_replace([
       { :search => /:(\w+)(?=\s*=>)/, :replace => '"\1"'},
       { :search => /((?:\{|,|^)\s*)(\w+):/, :replace => '\1"\2" =>'},
+    ])
+  end
+
+  def self.to_single_quoted_strings
+    search_and_replace([
+      { :search => /:(\w+)(?=\s*=>)/, :replace => "'\\1'"},
+      { :search => /((?:\{|,|^)\s*)(\w+):/, :replace => "\\1'\\2' =>"},
     ])
   end
 


### PR DESCRIPTION
Added a new shortcut, <Leader>rq that replaces symbols with single-quoted strings instead of double quoted.
